### PR TITLE
Caching response with mustache, compiling mustache afterwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Valid $options keys to pass to the `OrbitClient` are:
 * `cacheTime`: By default the Client uses the cache control headers of the API
   response determine how long to cache for. To override this value set the
   `cacheTime` to a value in seconds.
+* `mustache`: An array of options to pass to the `Mustache_Engine` such as `cache`.
+   Check the [Mustache Wiki for available options](https://github.com/bobthecow/mustache.php/wiki#constructor-options).
 
 ### Branding Object
 

--- a/src/OrbitClient.php
+++ b/src/OrbitClient.php
@@ -29,10 +29,12 @@ class OrbitClient
      *
      * env is the environment to point at. One of 'int', 'test' or 'live'
      * cacheTime is the number of seconds that the result should be stored
+     * mustache is the options array that should be passed to Mustache_Engine
      */
     private $options = [
         'env' => 'live',
         'cacheTime' => null,
+        'mustache' => [],
     ];
 
     public function __construct(
@@ -74,7 +76,7 @@ class OrbitClient
     {
         $url = $this->getUrl();
         $headers = $this->getRequestHeaders($requestParams);
-        $cacheKey = 'BBC_BRANDING_ORBIT_' . md5($url . json_encode($requestParams) . json_encode($templateParams));
+        $cacheKey = 'BBC_BRANDING_ORBIT_' . md5($url . json_encode($requestParams));
 
         /** @var CacheItemInterface $cacheItem */
         $cacheItem = $this->cache->getItem($cacheKey);
@@ -91,8 +93,6 @@ class OrbitClient
             if (!$result || !isset($result['head'])) {
                 throw new OrbitException('Invalid Orbit Response. Response JSON object was invalid or malformed');
             }
-
-            $result = $this->renderOrbResponse($result, $templateParams);
 
             // Determine how long to cache for
             $cacheTime = self::FALLBACK_CACHE_DURATION;
@@ -117,11 +117,14 @@ class OrbitClient
             $this->cache->save($cacheItem);
         }
 
-        $result = $cacheItem->get();
+        $cachedResponse = $cacheItem->get();
+
+        $output = $this->renderOrbResponse($cachedResponse, $templateParams);
+
         return new Orbit(
-            $result['head'],
-            $result['bodyFirst'],
-            $result['bodyLast']
+            $output['head'],
+            $output['bodyFirst'],
+            $output['bodyLast']
         );
     }
 
@@ -179,7 +182,7 @@ class OrbitClient
         $orbitFields = ['head', 'bodyFirst', 'bodyLast'];
 
         if ($params) {
-            $mustache = new Mustache_Engine();
+            $mustache = new Mustache_Engine($this->options['mustache']);
             foreach ($orbitFields as $orbitField) {
                 $orbitItem[$orbitField] = $mustache->render(
                     $result[$orbitField]['template'],

--- a/tests/BrandingClientTest.php
+++ b/tests/BrandingClientTest.php
@@ -164,7 +164,7 @@ class BrandingClientTest extends MultiGuzzleTestCase
               ->getMock();
 
         $cache->expects($this->once())->method('save')->with($this->callback(
-            function($cacheItemToSave) use ($expectedCacheDuration) {
+            function ($cacheItemToSave) use ($expectedCacheDuration) {
                 $current = time() + $expectedCacheDuration;
                 $this->assertAttributeEquals($current, 'expiry', $cacheItemToSave);
                 return true;

--- a/tests/OrbitClientTest.php
+++ b/tests/OrbitClientTest.php
@@ -20,6 +20,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
         $expectedDefaultOptions = [
             'env' => 'live',
             'cacheTime' => null,
+            'mustache' => [],
         ];
 
         $orbitClient = new OrbitClient(
@@ -35,6 +36,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
         $options = [
             'env' => 'test',
             'cacheTime' => 10,
+            'mustache' => ['someconfig'],
         ];
 
         $orbitClient = new OrbitClient(
@@ -42,7 +44,6 @@ class OrbitClientTest extends MultiGuzzleTestCase
             $this->cache,
             $options
         );
-
 
         $this->assertEquals($options, $orbitClient->getOptions());
     }
@@ -181,7 +182,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
                       ->getMock();
 
         $cache->expects($this->once())->method('save')->with($this->callback(
-            function($cacheItemToSave) use ($expectedCacheDuration) {
+            function ($cacheItemToSave) use ($expectedCacheDuration) {
                 $current = time() + $expectedCacheDuration;
                 $this->assertAttributeEquals($current, 'expiry', $cacheItemToSave);
                 return true;


### PR DESCRIPTION
This should reduce the number of similar cached items. But may increase load time a tiny bit because the mustache will need to be compiled each time.