### PR TITLE
Adding .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/script export-ignore
+/tests export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore


### PR DESCRIPTION
Adding .gitattributes should mean we can reduce the size of the package from around 3.5MB to around 900KB when building applications that use this package using the --prefer-dist flag on composer.
It does this by ignoring files/directories that are not require in production such as tests and READMEs.
For more information have a look at https://blog.madewithlove.be/post/gitattributes/ or https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/