### PR TITLE
Add a cacheKeyPrefix option to BrandingClient and OrbitClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Valid $options keys to pass to the `BrandingClient` are:
 
 * `env`: To set an environment to request Branding from. Must be one of
   'live', 'test' or 'int'. If omitted, shall default to 'live'.
+* `cacheKeyPrefix`: A prefix to use for the cache key. If omitted, shall default
+  to 'branding'.
 * `cacheTime`: By default the Client uses the cache control headers of the API
   response determine how long to cache for. To override this value set the
   `cacheTime` to a value in seconds.
@@ -99,6 +101,8 @@ Valid $options keys to pass to the `OrbitClient` are:
 
 * `env`: To set an environment to request Orbit from. Must be one of
   'live', 'test' or 'int'. If omitted, shall default to 'live'.
+* `cacheKeyPrefix`: A prefix to use for the cache key. If omitted, shall default
+  to 'orbit'.
 * `cacheTime`: By default the Client uses the cache control headers of the API
   response determine how long to cache for. To override this value set the
   `cacheTime` to a value in seconds.

--- a/src/BrandingClient.php
+++ b/src/BrandingClient.php
@@ -43,6 +43,7 @@ class BrandingClient
      */
     private $options = [
         'env' => 'live',
+        'cacheKeyPrefix' => 'branding',
         'cacheTime' => null,
     ];
 
@@ -75,7 +76,7 @@ class BrandingClient
     public function getContent($projectId, $themeVersionId = null)
     {
         $url = $this->getUrl($projectId, $themeVersionId);
-        $cacheKey = 'BBC_BRANDING_' . md5($url);
+        $cacheKey = $this->options['cacheKeyPrefix'] . '.' . md5($url);
 
         /** @var CacheItemInterface $cacheItem */
         $cacheItem = $this->cache->getItem($cacheKey);

--- a/src/OrbitClient.php
+++ b/src/OrbitClient.php
@@ -34,6 +34,7 @@ class OrbitClient
      */
     private $options = [
         'env' => 'live',
+        'cacheKeyPrefix' => 'orbit',
         'cacheTime' => null,
         'mustache' => [],
     ];
@@ -77,7 +78,7 @@ class OrbitClient
     {
         $url = $this->getUrl();
         $headers = $this->getRequestHeaders($requestParams);
-        $cacheKey = 'BBC_BRANDING_ORBIT_' . md5($url . json_encode($requestParams));
+        $cacheKey = $this->options['cacheKeyPrefix'] . '.' . md5($url . json_encode($requestParams));
 
         /** @var CacheItemInterface $cacheItem */
         $cacheItem = $this->cache->getItem($cacheKey);

--- a/tests/BrandingClientTest.php
+++ b/tests/BrandingClientTest.php
@@ -19,6 +19,7 @@ class BrandingClientTest extends MultiGuzzleTestCase
     {
         $expectedDefaultOptions = [
             'env' => 'live',
+            'cacheKeyPrefix' => 'branding',
             'cacheTime' => null,
         ];
 
@@ -34,6 +35,7 @@ class BrandingClientTest extends MultiGuzzleTestCase
     {
         $options = [
             'env' => 'test',
+            'cacheKeyPrefix' => 'branding.123',
             'cacheTime' => 10,
         ];
 
@@ -155,6 +157,8 @@ class BrandingClientTest extends MultiGuzzleTestCase
      */
     public function testCachingTimes($options, $headers, $expectedCacheDuration)
     {
+        $expectedKey = 'branding.b22b2e21ce267c3879b21fd96939bfd3';
+
         $client = $this->getClient([$this->mockSuccessfulJsonResponse($headers)]);
         $cache = $this->getMockBuilder('Symfony\Component\Cache\Adapter\NullAdapter')
             ->disableOriginalClone()
@@ -164,8 +168,9 @@ class BrandingClientTest extends MultiGuzzleTestCase
             ->getMock();
 
         $cache->expects($this->once())->method('save')->with($this->callback(
-            function ($cacheItemToSave) use ($expectedCacheDuration) {
+            function ($cacheItemToSave) use ($expectedKey, $expectedCacheDuration) {
                 $current = time() + $expectedCacheDuration;
+                $this->assertEquals($expectedKey, $cacheItemToSave->getKey());
                 $this->assertAttributeEquals($current, 'expiry', $cacheItemToSave);
                 return true;
             }

--- a/tests/OrbitClientTest.php
+++ b/tests/OrbitClientTest.php
@@ -19,6 +19,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
     {
         $expectedDefaultOptions = [
             'env' => 'live',
+            'cacheKeyPrefix' => 'orbit',
             'cacheTime' => null,
             'mustache' => [],
         ];
@@ -35,6 +36,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
     {
         $options = [
             'env' => 'test',
+            'cacheKeyPrefix' => 'orbit.123',
             'cacheTime' => 10,
             'mustache' => ['someconfig'],
         ];
@@ -174,6 +176,8 @@ class OrbitClientTest extends MultiGuzzleTestCase
      */
     public function testCachingTimes($options, $headers, $expectedCacheDuration)
     {
+        $expectedKey = 'orbit.5617e91c21636eb642dbeabcfb06342c';
+
         $client = $this->getClient([$this->mockSuccessfulJsonResponse($headers)]);
 
         $cache = $this->getMockBuilder('Symfony\Component\Cache\Adapter\NullAdapter')
@@ -184,8 +188,9 @@ class OrbitClientTest extends MultiGuzzleTestCase
             ->getMock();
 
         $cache->expects($this->once())->method('save')->with($this->callback(
-            function ($cacheItemToSave) use ($expectedCacheDuration) {
+            function ($cacheItemToSave) use ($expectedKey, $expectedCacheDuration) {
                 $current = time() + $expectedCacheDuration;
+                $this->assertEquals($expectedKey, $cacheItemToSave->getKey());
                 $this->assertAttributeEquals($current, 'expiry', $cacheItemToSave);
                 return true;
             }


### PR DESCRIPTION
This allows the consuming application to customise the cache key that
is stored.