### PR TITLE
Add option to use cloud idcta

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Valid $options keys to pass to the `OrbitClient` are:
    Check the [Mustache Wiki for available options](https://github.com/bobthecow/mustache.php/wiki#constructor-options).
 * `useCloudIdcta`: boolean, `false` by default, indicating whether requests to navigation.<env>.bbc.co.uk should include
    X-Feature header, [accommodating cloud idcta](https://confluence.dev.bbc.co.uk/pages/viewpage.action?pageId=117803057)
+    
 ### Branding Object
 
 The `Branding` object returned from `BrandingClient->getContent()` is a domain

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Valid $options keys to pass to the `OrbitClient` are:
   `cacheTime` to a value in seconds.
 * `mustache`: An array of options to pass to the `Mustache_Engine` such as `cache`.
    Check the [Mustache Wiki for available options](https://github.com/bobthecow/mustache.php/wiki#constructor-options).
-
+* `useCloudIdcta`: boolean, `false` by default, indicating whether requests to navigation.<env>.bbc.co.uk should include
+   X-Feature header, [accommodating cloud idcta](https://confluence.dev.bbc.co.uk/pages/viewpage.action?pageId=117803057)
 ### Branding Object
 
 The `Branding` object returned from `BrandingClient->getContent()` is a domain

--- a/src/OrbitClient.php
+++ b/src/OrbitClient.php
@@ -34,12 +34,15 @@ class OrbitClient
      * env is the environment to point at. One of 'int', 'test' or 'live'
      * cacheTime is the number of seconds that the result should be stored
      * mustache is the options array that should be passed to Mustache_Engine
+     * useCloudIdcta is a flag indicating whether requests to navigation.<env>.bbc.co.uk should include X-Feature header
+     *   (see https://confluence.dev.bbc.co.uk/pages/viewpage.action?pageId=117803057)
      */
     private $options = [
         'env' => 'live',
         'cacheKeyPrefix' => 'orbit',
         'cacheTime' => null,
         'mustache' => [],
+        'useCloudIdcta' => false,
     ];
 
     public function __construct(
@@ -179,12 +182,16 @@ class OrbitClient
      */
     private function getRequestHeaders(array $options)
     {
-        return [
+        $headers = [
             'Accept' => 'application/ld+json',
             'Accept-Encoding' => 'gzip',
             'Accept-Language' => isset($options['language']) ? $options['language'] : 'en',
             'X-Orb-Variant' => isset($options['variant']) ? $options['variant'] : 'default',
         ];
+        if ($this->options['useCloudIdcta'] == true) {
+            $headers['X-Feature'] = 'akamai-idcta';
+        }
+        return $headers;
     }
 
     /**

--- a/src/OrbitClient.php
+++ b/src/OrbitClient.php
@@ -188,7 +188,7 @@ class OrbitClient
             'Accept-Language' => isset($options['language']) ? $options['language'] : 'en',
             'X-Orb-Variant' => isset($options['variant']) ? $options['variant'] : 'default',
         ];
-        if ($this->options['useCloudIdcta'] == true) {
+        if ($this->options['useCloudIdcta']) {
             $headers['X-Feature'] = 'akamai-idcta';
         }
         return $headers;

--- a/tests/OrbitClientTest.php
+++ b/tests/OrbitClientTest.php
@@ -25,6 +25,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
             'cacheKeyPrefix' => 'orbit',
             'cacheTime' => null,
             'mustache' => [],
+            'useCloudIdcta' => false,
         ];
 
         $orbitClient = new OrbitClient(
@@ -42,6 +43,7 @@ class OrbitClientTest extends MultiGuzzleTestCase
             'cacheKeyPrefix' => 'orbit.123',
             'cacheTime' => 10,
             'mustache' => ['someconfig'],
+            'useCloudIdcta' => true,
         ];
 
         $orbitClient = new OrbitClient(
@@ -117,6 +119,11 @@ class OrbitClientTest extends MultiGuzzleTestCase
                     'Accept-Language' => ['cy_CY'],
                 ]
             ],
+
+            // With cloud idcta option set to true
+            [['env' => 'live', 'useCloudIdcta' => true], [], 'https://navigation.api.bbci.co.uk/api', [
+                'X-Feature' => ['akamai-idcta'],
+            ]],
         ];
     }
 


### PR DESCRIPTION
As part of the idcta cloud migration, a new header needs to be passed:
`X-Feature='akami-idcta'`
See https://confluence.dev.bbc.co.uk/pages/viewpage.action?pageId=117803057#idCTAAPI(platform-agnostic)-Migratingfrompaltocloud for details

The option to include this header is exposed to the users of this client
by setting the client construction option 'useCloudIdcta' to true